### PR TITLE
use simpler action with token

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,20 +70,9 @@ jobs:
       - name: Build pkgdown website
         run: pkgdown::build_site()
         shell: Rscript {0}
-      - name: Get system dependencies for github pages deploy
-        run: apt-get update -y && apt-get install -y ssh rsync
-      - name: Deploy pkgdown website to ref
-        if: github.event_name != 'pull_request' && github.ref != 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          ACCESS_TOKEN: ${{ secrets.GH_PAT }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs # The folder the action should deploy.
-          TARGET_FOLDER: ${{ github.ref }}
-      - name: Deploy pkgdown website to root
+      - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          ACCESS_TOKEN: ${{ secrets.GH_PAT }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs # The folder the action should deploy.
+        uses: maxheld83/ghpages@github-token
+        env:
+          BUILD_DIR: docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,6 @@ jobs:
         run: pkgdown::build_site()
         shell: Rscript {0}
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/master'
         uses: maxheld83/ghpages@github-token
         env:
           BUILD_DIR: docs


### PR DESCRIPTION
it's now possible to publish to github pages using the `secrets.GITHUB_TOKEN` that is always available in github actions runs.
This is much cleaner and also safer, because there are fewer PATs to worry about.

This ain't the real deal migration to muggle yet #17, just housekeeping.